### PR TITLE
Fixing that ~ is not expanded in ``~/.vst``.

### DIFF
--- a/obs-vst.cpp
+++ b/obs-vst.cpp
@@ -175,8 +175,8 @@ static void fill_out_plugins(obs_property_t *list)
 		         << "/usr/local/lib64/vst/"
 		         << "/usr/local/lib64/lxvst/"
 		         << "/usr/local/lib64/linux_vst/"
-		         << "~/.vst/"
-		         << "~/.lxvst/";
+		         << qEnvironmentVariable("HOME") + "/.vst/"
+		         << qEnvironmentVariable("HOME") + "/.lxvst/";
 	}
 #endif
 


### PR DESCRIPTION
Fixing that ~ is not expanded in ``~/.vst`` #64 

### How Has This Been Tested?
Tested on my computer (KUbuntu 20.04) by running OBS without a VST_PATH env variable and having plugins in ~/.vst. They are listed in the GUI.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
