### PR TITLE
Add module description

### DIFF
--- a/obs-vst.cpp
+++ b/obs-vst.cpp
@@ -29,6 +29,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("obs-vst", "en-US")
+MODULE_EXPORT const char *obs_module_description(void)
+{
+	return "VST 2.x Plug-in filter";
+}
 
 static bool open_editor_button_clicked(obs_properties_t *props, obs_property_t *property, void *data)
 {


### PR DESCRIPTION
### Description

Adds a module description to the OBS plugin.

### Motivation and Context

Consistent with other official/built-in plugins.

### How Has This Been Tested?

Modify `obs-module.c` to match this and launch
```c
void obs_log_loaded_modules(void)
{
	blog(LOG_INFO, "  Loaded Modules:");

	for (obs_module_t *mod = obs->first_module; !!mod; mod = mod->next)
		blog(LOG_INFO, "    %s		%s", mod->file,
		     obs_get_module_description(mod));
}
```

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
