### PR TITLE
obs-vst: Prevent crash loading VST plugins with many channels 

### DIFF
--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -19,7 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef OBS_STUDIO_VSTPLUGIN_H
 #define OBS_STUDIO_VSTPLUGIN_H
 
-#define VST_MAX_CHANNELS 8
 #define BLOCK_SIZE 512
 
 #include <mutex>
@@ -45,8 +44,12 @@ class VSTPlugin : public QObject {
 	obs_source_t *       sourceContext;
 	std::string          pluginPath;
 
-	float **inputs;
-	float **outputs;
+	float **inputs      = nullptr;
+	float **outputs     = nullptr;
+	float **channelrefs = nullptr;
+	size_t  numChannels = 0;
+	void    createChannelBuffers(size_t count);
+	void    cleanupChannelBuffers();
 
 	EditorWidget *editorWidget = nullptr;
 	bool          editorOpened = false;


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

When VST plugins that contained many channels or multiple buses were loaded, OBS would crash. This fix allows them to load and run properly.

This requires corresponding pull request https://github.com/obsproject/obs-studio/pull/3744 in the obs-studio repository that fixes initialization of the audio data pointers being passed in here, in order to function properly.


### Motivation and Context

Fixes crashing issues when attempting to use VST plugins that have many channels specifically.

### How Has This Been Tested?

This has been tested on macOS 10.15.6 using CoreAudio, so although the change is minimal and safe, it should still be tested on the other platforms. Several commercial plugins that have multiple output buses were tested that previously crashed OBS when loading.


### Types of changes

Bug fix

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested (on Mac)
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
