### PR TITLE
Replace QRegExp usage for better Qt6 compatibility

### DIFF
--- a/obs-vst.cpp
+++ b/obs-vst.cpp
@@ -210,11 +210,12 @@ static void fill_out_plugins(obs_property_t *list)
 			QString name = it.fileName();
 
 #ifdef __APPLE__
-			name.remove(QRegExp("(\\.vst)"));
+			name.remove(".vst", Qt::CaseInsensitive);
 #elif WIN32
-			name.remove(QRegExp("(\\.dll)"));
+			name.remove(".dll", Qt::CaseInsensitive);
 #elif __linux__
-			name.remove(QRegExp("(\\.so|\\.o)"));
+			name.remove(".so", Qt::CaseInsensitive);
+			name.remove(".o", Qt::CaseInsensitive);
 #endif
 
 			name.append("=").append(path);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Replace QRegExp usage for better Qt6 compatibility.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The existing QRegExp usages are just doing basic string matching to remove filename extensions. QRegExp was removed in Qt6, so let's just use QString for this functionality instead.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I don't have any VSTs installed on my system, so I haven't tested this.  I'll need someone else to make sure that this change is acceptable.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
