### PR TITLE
Remove Qt5MacExtras

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}")
 set(CMAKE_AUTOMOC TRUE)
 find_package(Qt5Widgets REQUIRED)
 
-if(APPLE)
-	find_package(Qt5MacExtras REQUIRED)
-endif(APPLE)
-
 option(VST_USE_BUNDLED_HEADERS "Build with Bundled Headers" ON)
 
 if(VST_USE_BUNDLED_HEADERS)
@@ -82,8 +78,7 @@ set_target_properties(obs-vst PROPERTIES FOLDER "plugins")
 if(APPLE)
 	target_link_libraries(obs-vst
 		${COCOA_FRAMEWORK}
-		${FOUNDATION_FRAMEWORK}
-		Qt5::MacExtras)
+		${FOUNDATION_FRAMEWORK})
 endif(APPLE)
 
 install_obs_plugin_with_data(obs-vst data)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
QtMacExtras is currently not in Qt6 and there's no word on if/when it will be reintroduced. We don't appear to be using it, so let's remove it.

Looking through Qt6 compat stuff - Qt Mac Extras currently isn't in Qt6 and has no ETA on if/when it'll be reintroduced.  I was looking at our code base to see if we can just remove it, and I don't actually see that we include QtMacExtras in code.  We do use QMacCocoaViewContainer in obs-vst, but I can't tell if that's now included in Qt Widgets directly.  QMacCocoaViewContainer is listed under the "See also" section in QtMacExtras docs, but it's shown in the Qt Widgets documentation.

It might be easiest to just make a PR removing it and seeing if it builds and runs on macOS, so let's try it.
https://github.com/obsproject/obs-studio/pull/1186
https://doc.qt.io/qt-5/qtmacextras-index.html
https://doc.qt.io/qt-5/qtmacextras-module.html
https://doc.qt.io/qt-5/qmaccocoaviewcontainer.html

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Make it easier for us to build everything on Qt6.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I ran this through CI on my fork, and it compiled.  Currently awaiting testing from macOS users (@DDRBoxman, @PatTheMav) to see if it runs without issue.

https://github.com/RytoEX/obs-studio/tree/remove-qtmacextras-test
https://github.com/RytoEX/obs-studio/runs/2079158979

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
