### PR TITLE
Fix VST_PATH use under Linux

### DIFF
--- a/obs-vst.cpp
+++ b/obs-vst.cpp
@@ -161,10 +161,9 @@ static void fill_out_plugins(obs_property_t *list)
 	// If the user has set the VST_PATH environmental
 	// variable, then use it. Else default to a list
 	// of common locations.
-	char *vstPathEnv;
-	vstPathEnv = getenv("VST_PATH");
-	if (vstPathEnv != nullptr) {
-		dir_list << vstPathEnv;
+	QString vstPathEnv(getenv("VST_PATH"));
+	if (!vstPathEnv.isNull()) {
+		dir_list.append(vstPathEnv.split(":"));
 	} else {
 		QString home(getenv("HOME"));
 		// Choose the most common locations


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
I just fixed the usage of $VST_PATH under Linux.

When you use getenv("VST_PATH"), we only get a string like this `/home/user/.vst:/usr/lib/vst:/usr/local/lib/vst` and this string is considered as one and only directory path.

So I fixed it.
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This plugin didn't get any VST plugin if there is multiple path in VST_PATH. And with this fix it's solved.

<!--- If it fixes an open GitHub Issue, or implements feature request -->
May fix #64 
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I launched OBS with this fix and the VST plugins were found, with:
- my default VST_PATH which has multiple paths
- set VST_PATH with only one path in a terminal
- by using "unset VST_PATH" and "obs" in a terminal
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
