### PR TITLE
Fix button states on properties refresh

### DIFF
--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -162,6 +162,11 @@ void VSTPlugin::unloadEffect()
 	unloadLibrary();
 }
 
+bool VSTPlugin::isEditorOpen()
+{
+	return editorWidget ? true : false;
+}
+
 void VSTPlugin::openEditor()
 {
 	if (effect && !editorWidget) {

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -99,6 +99,8 @@ public:
 	obs_audio_data *process(struct obs_audio_data *audio);
 	bool            openInterfaceWhenActive = false;
 
+	bool isEditorOpen();
+
 public slots:
 	void openEditor();
 	void closeEditor();

--- a/obs-vst.cpp
+++ b/obs-vst.cpp
@@ -237,20 +237,23 @@ static void fill_out_plugins(obs_property_t *list)
 
 static obs_properties_t *vst_properties(void *data)
 {
-	obs_properties_t *props = obs_properties_create();
-	obs_property_t *  list  = obs_properties_add_list(
+	VSTPlugin *       vstPlugin = (VSTPlugin *)data;
+	obs_properties_t *props     = obs_properties_create();
+	obs_property_t *  list      = obs_properties_add_list(
                 props, "plugin_path", PLUG_IN_NAME, OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_STRING);
 
 	fill_out_plugins(list);
 
 	obs_properties_add_button(props, OPEN_VST_SETTINGS, OPEN_VST_TEXT, open_editor_button_clicked);
-
 	obs_properties_add_button(props, CLOSE_VST_SETTINGS, CLOSE_VST_TEXT, close_editor_button_clicked);
-	obs_property_set_visible(obs_properties_get(props, CLOSE_VST_SETTINGS), false);
+
+	if (vstPlugin->isEditorOpen()) {
+		obs_property_set_visible(obs_properties_get(props, OPEN_VST_SETTINGS), false);
+	} else {
+		obs_property_set_visible(obs_properties_get(props, CLOSE_VST_SETTINGS), false);
+	}
 
 	obs_properties_add_bool(props, OPEN_WHEN_ACTIVE_VST_SETTINGS, OPEN_WHEN_ACTIVE_VST_TEXT);
-
-	UNUSED_PARAMETER(data);
 
 	return props;
 }


### PR DESCRIPTION
Properties creation checks whether the current plugin has it's
editor window open or not. Depending on if it is or not the
states of the open/close editor buttons are set accordingly.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change adds a function for querying the current plugin's state of its editor window - if it is currently shown or not. Upon properties creation the buttons for opening and closing the editor window are shown and hid according of the return value of that function.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Current behavior is a little broken on focus changes(?). At the moment when opening an editor window, the controls are correctly changed to "close" the opened editor window. The new editor window gets the current focus. When returning the focus to the VST OBS property window the properties are getting refreshed and default to their initial state. This indicates the incorrect state of the editor window and one would have to click the "open" button once again to trigger the (noop) editor window again to get the "close" button to correctly appear to close the editor again.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Current behavior and fix tested on Linux (current behavior was also verified on Windows, fix untested there, but should be platform independent)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
