### PR TITLE
obs-vst: Update CMakeLists for modern builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,84 +1,132 @@
-if(DISABLE_UI)
-	message(STATUS "UI disabled,so vst plugin disabled")
-	return()
-endif()
-if(DISABLE_VST)
-	message(STATUS "obs-vst is disabled")
-	return()
-endif()
-
 project(obs-vst)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}")
+macro(find_qt)
+  set(oneValueArgs VERSION)
+  set(multiValueArgs COMPONENTS COMPONENTS_WIN COMPONENTS_MAC COMPONENTS_LINUX)
+  cmake_parse_arguments(FIND_QT "" "${oneValueArgs}" "${multiValueArgs}"
+                        ${ARGN})
 
-set(CMAKE_AUTOMOC TRUE)
-find_package(Qt5Widgets REQUIRED)
+  if(OS_WINDOWS)
+    find_package(
+      Qt${FIND_QT_VERSION}
+      COMPONENTS ${FIND_QT_COMPONENTS} ${FIND_QT_COMPONENTS_WIN}
+      REQUIRED)
+  elseif(OS_MACOS)
+    find_package(
+      Qt${FIND_QT_VERSION}
+      COMPONENTS ${FIND_QT_COMPONENTS} ${FIND_QT_COMPONENTS_MAC}
+      REQUIRED)
+  else()
+    find_package(
+      Qt${FIND_QT_VERSION}
+      COMPONENTS ${FIND_QT_COMPONENTS} ${FIND_QT_COMPONENTS_LINUX}
+      REQUIRED)
+  endif()
 
-option(VST_USE_BUNDLED_HEADERS "Build with Bundled Headers" ON)
+  foreach(_COMPONENT IN LISTS FIND_QT_COMPONENTS FIND_QT_COMPONENTS_WIN
+                              FIND_QT_COMPONENTS_MAC FIND_QT_COMPONENTS_LINUX)
+    if(NOT TARGET Qt::${_COMPONENT} AND TARGET
+                                        Qt${FIND_QT_VERSION}::${_COMPONENT})
 
-if(VST_USE_BUNDLED_HEADERS)
-	message(STATUS "Using the bundled VST header.")
-	include_directories(vst_header)
-	set(vst_HEADER
-		vst_header/aeffectx.h)
+      add_library(Qt::${_COMPONENT} INTERFACE IMPORTED)
+      set_target_properties(
+        Qt::${_COMPONENT} PROPERTIES INTERFACE_LINK_LIBRARIES
+                                     "Qt${FIND_QT_VERSION}::${_COMPONENT}")
+    endif()
+  endforeach()
+endmacro()
+
+option(ENABLE_VST "Enable building OBS with VST plugin" ON)
+
+if(NOT ENABLE_VST)
+  message(STATUS "OBS:  DISABLED   obs-vst")
+  return()
+endif()
+
+option(ENABLE_VST_BUNDLED_HEADERS "Build with Bundled Headers" ON)
+mark_as_advanced(ENABLE_VST_BUNDLED_HEADERS)
+
+if(NOT QT_VERSION)
+  set(QT_VERSION
+      "5"
+      CACHE STRING
+            "OBS Qt version [5, 6]" FORCE)
+  set_property(CACHE QT_VERSION PROPERTY STRINGS 5 6)
+endif()
+
+add_library(obs-vst MODULE)
+add_library(OBS::vst ALIAS obs-vst)
+
+find_qt(VERSION ${QT_VERSION} COMPONENTS Widgets)
+
+set_target_properties(
+  obs-vst
+  PROPERTIES AUTOMOC ON
+             AUTOUIC ON
+             AUTORCC ON)
+
+target_include_directories(
+  obs-vst PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+                  ${CMAKE_CURRENT_BINARY_DIR})
+
+target_sources(
+  obs-vst
+  PRIVATE obs-vst.cpp VSTPlugin.cpp EditorWidget.cpp
+          headers/vst-plugin-callbacks.hpp headers/EditorWidget.h
+          headers/VSTPlugin.h)
+
+target_link_libraries(obs-vst PRIVATE OBS::libobs Qt::Widgets)
+
+target_include_directories(
+  obs-vst PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/headers)
+
+target_compile_features(obs-vst PRIVATE cxx_std_17)
+
+if(ENABLE_VST_BUNDLED_HEADERS)
+  message(STATUS "OBS:    -        obs-vst uses bundled VST headers")
+
+  target_sources(obs-vst PRIVATE vst_header/aeffectx.h)
+
+  target_include_directories(obs-vst
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/vst_header)
 else()
-	set(VST_INCLUDE_DIR "" CACHE PATH
-		"Path to Steinburg headers (e.g. C:/VST3 SDK/pluginterfaces/vst2.x)")
+  set(VST_INCLUDE_DIR
+      ""
+      CACHE PATH
+            "Path to Steinburg headers (e.g. C:/VST3 SDK/pluginterfaces/vst2.x)"
+            FORCE)
+  mark_as_advanced(VST_INCLUDE_DIR)
 
-	message(WARNING "You should only use the Steinburg headers for debugging or local
-	 builds. It is illegal to distribute the Steinburg headers with anything, and
-	 possibly against the GPL to distribute the binaries from the resultant compile.")
-	include_directories(${VST_INCLUDE_DIR})
-	set(vst_HEADER
-		${VST_INCLUDE_DIR}/aeffectx.h)
+  message(
+    WARNING
+      "OBS: You should only use the Steinburg headers for debugging or local builds. "
+      "It is illegal to distribute the Steinburg headers with anything, and "
+      "possibly against the GPL to distribute the binaries from the resultant compile."
+  )
+
+  target_sources(obs-vst PRIVATE ${VST_INCLUDE_DIR}/aeffectx.h)
 endif()
 
-if(APPLE)
-	find_library(FOUNDATION_FRAMEWORK Foundation)
-	find_library(COCOA_FRAMEWORK Cocoa)
-endif(APPLE)
+if(OS_MACOS)
+  find_library(FOUNDATION Foundation)
+  find_library(COCOA Cocoa)
+  mark_as_advanced(COCOA FOUNDATION)
 
-set(obs-vst_SOURCES
-	obs-vst.cpp
-	VSTPlugin.cpp
-	EditorWidget.cpp)
+  target_sources(obs-vst PRIVATE mac/VSTPlugin-osx.mm mac/EditorWidget-osx.mm)
 
-if(APPLE)
-	list(APPEND obs-vst_SOURCES
-		mac/VSTPlugin-osx.mm
-		mac/EditorWidget-osx.mm)
+  target_link_libraries(obs-vst PRIVATE ${COCOA} ${FOUNDATION})
 
-elseif(WIN32)
-	list(APPEND obs-vst_SOURCES
-		win/VSTPlugin-win.cpp
-		win/EditorWidget-win.cpp)
+elseif(OS_WINDOWS)
+  target_sources(obs-vst PRIVATE win/VSTPlugin-win.cpp win/EditorWidget-win.cpp)
 
-elseif("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
-	list (APPEND obs-vst_SOURCES
-		linux/VSTPlugin-linux.cpp
-		linux/EditorWidget-linux.cpp)
+  target_compile_definitions(obs-vst PRIVATE UNICODE _UNICODE)
+
+elseif(OS_POSIX)
+  target_sources(obs-vst PRIVATE linux/VSTPlugin-linux.cpp
+                                 linux/EditorWidget-linux.cpp)
+
 endif()
 
-list(APPEND obs-vst_HEADERS
-	headers/vst-plugin-callbacks.hpp
-	headers/EditorWidget.h
-	headers/VSTPlugin.h)
+set_target_properties(obs-vst PROPERTIES FOLDER "plugins" PREFIX "")
 
-add_library(obs-vst MODULE
-	${obs-vst_SOURCES}
-	${obs-vst_HEADERS}
-	${vst-HEADER})
-
-target_link_libraries(obs-vst
-	libobs
-	Qt5::Widgets)
-
-set_target_properties(obs-vst PROPERTIES FOLDER "plugins")
-
-if(APPLE)
-	target_link_libraries(obs-vst
-		${COCOA_FRAMEWORK}
-		${FOUNDATION_FRAMEWORK})
-endif(APPLE)
-
-install_obs_plugin_with_data(obs-vst data)
+setup_plugin_target(obs-vst)


### PR DESCRIPTION
### Description
This is a companion PR for https://github.com/obsproject/obs-studio/pull/4560 to update obs-vst with the changes introduced by that PR.

### Motivation and Context
Updates the CMake build scripts to use modern target-based semantics.

### How Has This Been Tested?
* OBS built with obs-vst on Linux, macOS and Windows

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
