### PR TITLE
Replace QMacCocoaViewContainer with QWidget::createWindowContainer

### DIFF
--- a/headers/EditorWidget.h
+++ b/headers/EditorWidget.h
@@ -49,7 +49,7 @@ class EditorWidget : public QWidget {
 	VSTPlugin *plugin;
 
 #ifdef __APPLE__
-	QMacCocoaViewContainer *cocoaViewContainer = NULL;
+	QWidget *cocoaViewContainer = NULL;
 #elif WIN32
 	HWND windowHandle = NULL;
 #elif __linux__

--- a/mac/EditorWidget-osx.mm
+++ b/mac/EditorWidget-osx.mm
@@ -17,17 +17,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #import "../headers/EditorWidget.h"
 #import <Cocoa/Cocoa.h>
 #include <QLayout>
+#include <QWindow>
 
 #import "../headers/VSTPlugin.h"
 
 void EditorWidget::buildEffectContainer(AEffect *effect) {
-  cocoaViewContainer = new QMacCocoaViewContainer(nullptr, this);
+  NSView *view = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300)];
+  cocoaViewContainer =
+      QWidget::createWindowContainer(QWindow::fromWinId(WId(view)));
   cocoaViewContainer->move(0, 0);
   cocoaViewContainer->resize(300, 300);
-  NSView *view = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300)];
-
-  cocoaViewContainer->setCocoaView(view);
-
   cocoaViewContainer->show();
 
   auto *hblParams = new QHBoxLayout();
@@ -57,7 +56,7 @@ void EditorWidget::buildEffectContainer(AEffect *effect) {
 void EditorWidget::handleResizeRequest(int width, int height) {
   resize(width, height);
   cocoaViewContainer->resize(width, height);
-  NSView *view = cocoaViewContainer->cocoaView();
+  NSView *view = reinterpret_cast<NSView *>(cocoaViewContainer->winId());
   NSRect frame = NSMakeRect(0, 0, width, height);
 
   [view setFrame:frame];


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Replaces the deprecated QMacCocoaViewContainer() with QWidget::createWindowContainer.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
QMacCocoaViewContainer was deprecated at some point in QT5 and removed
in QT6. Without this, OBS can't get fully compiled and packaged on QT6 on macOS.
Also removes the deprecation warnings on QT5.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0.1, compiled and run.
VST plug-in interface works, opens and closes as it did before.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
