### PR TITLE
obs-vst: Fix crash caused by unsupported interface

### DIFF
--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -85,7 +85,7 @@ void VSTPlugin::loadEffectFromPath(std::string path)
 			return;
 		}
 
-		// this check logic is refer to open source project : Audacity
+		// This check logic is refer to open source project : Audacity
 		if ((effect->flags & effFlagsIsSynth) || !(effect->flags & effFlagsCanReplacing)) {
 			blog(LOG_WARNING, "VST Plug-in can't support replacing. '%s'", path.c_str());
 			return;
@@ -171,6 +171,12 @@ void VSTPlugin::unloadEffect()
 void VSTPlugin::openEditor()
 {
 	if (effect && !editorWidget) {
+		// This check logic is refer to open source project : Audacity
+		if (!(effect->flags & effFlagsHasEditor)) {
+			plog(LOG_WARNING, "VST Plug-in: Can't support edit feature. '%s'", pluginPath.c_str());
+			return;
+		}
+
 		editorWidget = new EditorWidget(nullptr, this);
 		editorWidget->buildEffectContainer(effect);
 

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -94,6 +94,9 @@ void VSTPlugin::loadEffectFromPath(std::string path)
 		effect->dispatcher(effect, effGetEffectName, 0, 0, effectName, 0);
 		effect->dispatcher(effect, effGetVendorString, 0, 0, vendorString, 0);
 
+		// Ask the plugin to identify itself...might be needed for older plugins
+		effect->dispatcher(effect, effIdentify, 0, 0, nullptr, 0.0f);
+
 		effect->dispatcher(effect, effOpen, 0, 0, nullptr, 0.0f);
 
 		// Set some default properties

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -85,6 +85,12 @@ void VSTPlugin::loadEffectFromPath(std::string path)
 			return;
 		}
 
+		// this check logic is refer to open source project : Audacity
+		if ((effect->flags & effFlagsIsSynth) || !(effect->flags & effFlagsCanReplacing)) {
+			blog(LOG_WARNING, "VST Plug-in can't support replacing. '%s'", path.c_str());
+			return;
+		}
+
 		effect->dispatcher(effect, effGetEffectName, 0, 0, effectName, 0);
 		effect->dispatcher(effect, effGetVendorString, 0, 0, vendorString, 0);
 

--- a/win/VSTPlugin-win.cpp
+++ b/win/VSTPlugin-win.cpp
@@ -70,12 +70,12 @@ AEffect *VSTPlugin::loadEffect()
 		plog(LOG_WARNING, "VST plugin initialization failed");
 		return nullptr;
 	}
- 
-  if (plugin == nullptr) {
-    blog(LOG_WARNING, "Couldn't create instance for '%s'", pluginPath.c_str());
+
+	if (plugin == nullptr) {
+		blog(LOG_WARNING, "Couldn't create instance for '%s'", pluginPath.c_str());
 		return nullptr;
-  }
-  
+	}
+
 	plugin->user = this;
 	return plugin;
 }

--- a/win/VSTPlugin-win.cpp
+++ b/win/VSTPlugin-win.cpp
@@ -64,7 +64,13 @@ AEffect *VSTPlugin::loadEffect()
 	}
 
 	// Instantiate the plug-in
-	plugin       = mainEntryPoint(hostCallback_static);
+	try {
+		plugin = mainEntryPoint(hostCallback_static);
+	} catch (...) {
+		plog(LOG_WARNING, "VST plugin initialization failed");
+		return nullptr;
+	}
+
 	plugin->user = this;
 	return plugin;
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This pr fix some crash issues after researching code of https://github.com/audacity/audacity

After loading VST plugin, we must check its flag with effFlagsCanReplacing.
If effFlagsCanReplacing is not supported, crash will happen later when to call AEffect::processReplacing(...)

effFlagsHasEditor also should be checked before openning editor window.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
fix crash

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
tested on VST plugin named Microtonic Multi.dll.
[Microtonic Multi.zip](https://github.com/obsproject/obs-vst/files/7585233/Microtonic.Multi.zip)

### Types of changes
Bug fix (non-breaking change which fixes an issue)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- -  -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
