### PR TITLE
obs-vst: Use deleteLater on editorWidget to prevent crash

### DIFF
--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -184,13 +184,13 @@ void VSTPlugin::openEditor()
 
 void VSTPlugin::closeEditor()
 {
-	if (effect) {
-		effect->dispatcher(effect, effEditClose, 0, 0, nullptr, 0);
-	}
-
 	if (editorWidget) {
+		if (effect) {
+			effect->dispatcher(effect, effEditClose, 0, 0, nullptr, 0);
+		}
+
 		editorWidget->close();
-		delete editorWidget;
+		editorWidget->deleteLater();
 		editorWidget = nullptr;
 	}
 }

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -165,7 +165,8 @@ void VSTPlugin::unloadEffect()
 void VSTPlugin::openEditor()
 {
 	if (effect && !editorWidget) {
-		editorWidget = new EditorWidget(nullptr, this);
+		editorOpenned = true;
+		editorWidget  = new EditorWidget(nullptr, this);
 		editorWidget->buildEffectContainer(effect);
 
 		if (sourceName.empty()) {
@@ -185,7 +186,8 @@ void VSTPlugin::openEditor()
 void VSTPlugin::closeEditor()
 {
 	if (editorWidget) {
-		if (effect) {
+		if (effect && editorOpenned) {
+			editorOpenned = false;
 			effect->dispatcher(effect, effEditClose, 0, 0, nullptr, 0);
 		}
 

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -46,6 +46,7 @@ class VSTPlugin : public QObject {
 	float **outputs;
 
 	EditorWidget *editorWidget = nullptr;
+	bool          editorOpenned = false;
 
 	AEffect *loadEffect();
 

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -45,7 +45,7 @@ class VSTPlugin : public QObject {
 	float **inputs;
 	float **outputs;
 
-	EditorWidget *editorWidget = nullptr;
+	EditorWidget *editorWidget  = nullptr;
 	bool          editorOpenned = false;
 
 	AEffect *loadEffect();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
obs-vst crashes frequently after closing editor window and deleting vst filter.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
this issue may be same as #77 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
tested with pitchproof-x64.dll, many vst plugins can be reproduced
[pitchproof-x64.zip](https://github.com/obsproject/obs-vst/files/7586509/pitchproof-x64.zip)


### Types of change
Bug fix (non-breaking change which fixes an issue)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- -  -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
