### PR TITLE
obs-vst: Update effect name even effect is unavailable

### DIFF
--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -85,14 +85,15 @@ void VSTPlugin::loadEffectFromPath(std::string path)
 			return;
 		}
 
+		// It is better to invoke this code after checking magic number
+		effect->dispatcher(effect, effGetEffectName, 0, 0, effectName, 0);
+		effect->dispatcher(effect, effGetVendorString, 0, 0, vendorString, 0);
+
 		// This check logic is refer to open source project : Audacity
 		if ((effect->flags & effFlagsIsSynth) || !(effect->flags & effFlagsCanReplacing)) {
 			blog(LOG_WARNING, "VST Plug-in can't support replacing. '%s'", path.c_str());
 			return;
 		}
-
-		effect->dispatcher(effect, effGetEffectName, 0, 0, effectName, 0);
-		effect->dispatcher(effect, effGetVendorString, 0, 0, vendorString, 0);
 
 		// Ask the plugin to identify itself...might be needed for older plugins
 		effect->dispatcher(effect, effIdentify, 0, 0, nullptr, 0.0f);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
After choosing an unavailable effect, we should also update effect name.
Otherwize the editor title will be previous effect's.
But firstly we must check the magic number to make sure it is a vst2.x plugin.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
fix bug about title of editor window

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
steps:
select a valid effect and open editor window;
close editor window, choose an invalid effect, reopen editor window;
check the editor title

### Types of changes
Bug fix (non-breaking change which fixes an issue)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- -  -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
