### PR TITLE
obs-vst: Modify bug in VSTPlugin::closeEditor()

### DIFF
--- a/EditorWidget.cpp
+++ b/EditorWidget.cpp
@@ -29,7 +29,7 @@ void EditorWidget::closeEvent(QCloseEvent *event)
 #ifdef __APPLE__
 	event->ignore();
 #else
-	plugin->closeEditor();
+	plugin->onWidgetClosed();
 	UNUSED_PARAMETER(event);
 #endif
 }

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -178,6 +178,14 @@ bool VSTPlugin::isEditorOpen()
 	return editorWidget ? true : false;
 }
 
+void VSTPlugin::onWidgetClosed()
+{
+	if (editorWidget) {
+		editorWidget->deleteLater();
+		editorWidget = nullptr;
+	}
+}
+
 void VSTPlugin::openEditor()
 {
 	if (effect && !editorWidget) {
@@ -214,8 +222,6 @@ void VSTPlugin::closeEditor()
 		}
 
 		editorWidget->close();
-		editorWidget->deleteLater();
-		editorWidget = nullptr;
 	}
 }
 

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -101,6 +101,7 @@ public:
 	bool            openInterfaceWhenActive = false;
 
 	bool isEditorOpen();
+	void onWidgetClosed();
 
 public slots:
 	void openEditor();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
VSTPlugin::closeEditor() can be invoked again from VSTPlugin::closeEditor().
Second closeEditor() is invoked from editorWidget->close() in first closeEditor().
In second func, editorWidget will be set with NULL, then deleteLater() in first
func is using empty editorWidget

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
modify closeEditor()

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
select VST-1, open editor UI;
switch to VST-2

### Types of changes
Bug fix (non-breaking change which fixes an issue)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- -  -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
