### PR TITLE
obs-vst: Fix crash caused by mult-thread accessing to VSTPlugin::effect

### DIFF
--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -22,6 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VST_MAX_CHANNELS 8
 #define BLOCK_SIZE 512
 
+#include <mutex>
+#include <atomic>
 #include <string>
 #include <QDirIterator>
 #include <obs-module.h>
@@ -38,9 +40,10 @@ class EditorWidget;
 class VSTPlugin : public QObject {
 	Q_OBJECT
 
-	AEffect *     effect = nullptr;
-	obs_source_t *sourceContext;
-	std::string   pluginPath;
+	std::recursive_mutex lockEffect;
+	AEffect *            effect = nullptr;
+	obs_source_t *       sourceContext;
+	std::string          pluginPath;
 
 	float **inputs;
 	float **outputs;
@@ -50,7 +53,7 @@ class VSTPlugin : public QObject {
 
 	AEffect *loadEffect();
 
-	bool effectReady = false;
+	std::atomic_bool effectReady = false;
 
 	std::string sourceName;
 	std::string filterName;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
fix thread-safe issue for effect 

VSTPlugin::unloadEffect() is called from UI thread.
VSTPlugin::process is called from audio source 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
fix crash

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
select a vst for audio source;
keep switching vst

### Types of changes
Bug fix (non-breaking change which fixes an issue)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- -  -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
