### PR TITLE
obs-vst: Modify VSTPlugin::closeEditor()

### DIFF
--- a/EditorWidget.cpp
+++ b/EditorWidget.cpp
@@ -29,7 +29,7 @@ void EditorWidget::closeEvent(QCloseEvent *event)
 #ifdef __APPLE__
 	event->ignore();
 #else
-	plugin->closeEditor();
+	plugin->onEditorClosed();
 	UNUSED_PARAMETER(event);
 #endif
 }

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -178,6 +178,20 @@ bool VSTPlugin::isEditorOpen()
 	return editorWidget ? true : false;
 }
 
+void VSTPlugin::onEditorClosed()
+{
+	if (!editorWidget)
+		return;
+
+	if (effect && editorOpened) {
+		editorOpened = false;
+		effect->dispatcher(effect, effEditClose, 0, 0, nullptr, 0);
+	}
+
+	editorWidget->deleteLater();
+	editorWidget = nullptr;
+}
+
 void VSTPlugin::openEditor()
 {
 	if (effect && !editorWidget) {
@@ -207,18 +221,8 @@ void VSTPlugin::openEditor()
 
 void VSTPlugin::closeEditor()
 {
-	if (editorWidget) {
-		if (effect && editorOpened) {
-			editorOpened = false;
-			effect->dispatcher(effect, effEditClose, 0, 0, nullptr, 0);
-		}
-
-		EditorWidget *temp = editorWidget;
-		editorWidget       = nullptr;
-
-		temp->close();
-		temp->deleteLater();
-	}
+	if (editorWidget)
+		editorWidget->close();
 }
 
 intptr_t VSTPlugin::hostCallback(AEffect *effect, int32_t opcode, int32_t index, intptr_t value, void *ptr, float opt)

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -101,6 +101,7 @@ public:
 	bool            openInterfaceWhenActive = false;
 
 	bool isEditorOpen();
+	void onEditorClosed();
 
 public slots:
 	void openEditor();


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
About previous code, it combined doXXX() and onXXX(), which makes closeEditor() be invoked twice.
This is also the reason of issue in https://github.com/obsproject/obs-vst/pull/98

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
clean up code

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
close editor window by swtiching VST or clicking Close button

### Types of changes
Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- -  -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
