### PR TITLE
obs-vst: Fix crash by checking hash before applying "chunk_data"

### DIFF
--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -258,6 +258,11 @@ intptr_t VSTPlugin::hostCallback(AEffect *effect, int32_t opcode, int32_t index,
 	return result;
 }
 
+std::string VSTPlugin::getEffectPath()
+{
+	return pluginPath;
+}
+
 std::string VSTPlugin::getChunk()
 {
 	if (!effect) {

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -95,6 +95,7 @@ public:
 	~VSTPlugin();
 	void            loadEffectFromPath(std::string path);
 	void            unloadEffect();
+	std::string     getEffectPath();
 	std::string     getChunk();
 	void            setChunk(std::string data);
 	void            setProgram(const int programNumber);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Before applying chunk-data, we should check if data is for this VST plugin.
Some VST plugin will crash at effSetChunk if chunk-data is not for it.
Besides, it is meaningless to apply chunk-data to a mismatched VST plugin.

For example:
![1641373391](https://user-images.githubusercontent.com/18413354/148190625-1073a6ae-aaab-43cc-97c3-8ca247dfa25c.png)

It can also be reproduced with:
readelay-standalone.dll
BL-Denoiser.dll
spire-1.5.dll

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fix crash

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
switch selected VST and reboot OBS

### Types of changes
Bug fix (non-breaking change which fixes an issue)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- -  -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
