### PR TITLE
Fixing VST plug-ins disappearing when resized

### DIFF
--- a/win/EditorWidget-win.cpp
+++ b/win/EditorWidget-win.cpp
@@ -36,7 +36,6 @@ void EditorWidget::buildEffectContainer(AEffect *effect)
 
 	QWidget *widget = QWidget::createWindowContainer(QWindow::fromWinId((WId)windowHandle), this);
 	widget->move(0, 0);
-	widget->resize(300, 300);
 
 	effect->dispatcher(effect, effEditOpen, 0, 0, windowHandle, 0);
 
@@ -44,6 +43,9 @@ void EditorWidget::buildEffectContainer(AEffect *effect)
 	effect->dispatcher(effect, effEditGetRect, 0, 0, &vstRect, 0);
 	if (vstRect) {
 		widget->resize(vstRect->right - vstRect->left, vstRect->bottom - vstRect->top);
+		resize(vstRect->right - vstRect->left, vstRect->bottom - vstRect->top);
+	} else {
+		widget->resize(300, 300);
 	}
 }
 
@@ -53,36 +55,13 @@ void EditorWidget::handleResizeRequest(int, int)
 	// so we must resize window manually
 
 	// get pointer to vst effect from window long
-	LONG_PTR    wndPtr   = (LONG_PTR)GetWindowLongPtrW(windowHandle, -21 /*GWLP_USERDATA*/);
-	AEffect *   effect   = (AEffect *)(wndPtr);
-	VstRect *   rec      = nullptr;
-	static RECT PluginRc = {0};
-	RECT        winRect  = {0};
+	LONG_PTR wndPtr = (LONG_PTR)GetWindowLongPtrW(windowHandle, -21 /*GWLP_USERDATA*/);
+	AEffect *effect = (AEffect *)(wndPtr);
+	VstRect *rec    = nullptr;
 
-	GetWindowRect(windowHandle, &winRect);
-	if (effect) {
-		effect->dispatcher(effect, effEditGetRect, 1, 0, &rec, 0);
-	}
+	effect->dispatcher(effect, effEditGetRect, 0, 0, &rec, 0);
 
-	// compare window rect with VST Rect
 	if (rec) {
-		if (PluginRc.bottom != rec->bottom || PluginRc.left != rec->left || PluginRc.right != rec->right ||
-		    PluginRc.top != rec->top) {
-			PluginRc.bottom = rec->bottom;
-			PluginRc.left   = rec->left;
-			PluginRc.right  = rec->right;
-			PluginRc.top    = rec->top;
-
-			// set rect to our window
-			AdjustWindowRectEx(&PluginRc, WS_CAPTION | WS_THICKFRAME | WS_OVERLAPPEDWINDOW, FALSE, 0);
-
-			// move window to apply pos
-			MoveWindow(windowHandle,
-			           winRect.left,
-			           winRect.top,
-			           PluginRc.right - PluginRc.left,
-			           PluginRc.bottom - PluginRc.top,
-			           TRUE);
-		}
+		resize(rec->right - rec->left, rec->bottom - rec->top);
 	}
 }


### PR DESCRIPTION
Resizing VST editors when loaded in OBS Studio on Windows most often result in actual plug-in editor to disappear, and requires the window to be reopened. This change fixes the issue in most cases (except when the size of the plug-in decreases).

The original code directly uses the native window instead of the Qt container widget (which is not recommended in the Qt documentation), which results in resizing issues. Using the Qt container widget to resize the window instead fixes the problem, at least for some cases.

The remaining issue when size decreases is probably a problem with Qt and the specifics of the WindowContainer widget. Re-increasing the size of the plug-in editor or reopening the window fixes the problem.
