### PR TITLE
Fix size truncation warning for silenceChannel

### DIFF
--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -212,9 +212,9 @@ void VSTPlugin::loadEffectFromPath(std::string path)
 	}
 }
 
-void silenceChannel(float **channelData, int numChannels, long numFrames)
+static void silenceChannel(float **channelData, size_t numChannels, long numFrames)
 {
-	for (int channel = 0; channel < numChannels; ++channel) {
+	for (size_t channel = 0; channel < numChannels; ++channel) {
 		for (long frame = 0; frame < numFrames; ++frame) {
 			channelData[channel][frame] = 0.0f;
 		}


### PR DESCRIPTION
### Description
Also make function static since it's internal to the translation unit.

### Motivation and Context
Warnings are annoying.

### How Has This Been Tested?
Warning is gone.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.