### PR TITLE
obs-vst: Clear VST effect if user selects empty plugin

### DIFF
--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -133,7 +133,6 @@ void VSTPlugin::cleanupChannelBuffers()
 void VSTPlugin::loadEffectFromPath(std::string path)
 {
 	if (this->pluginPath.compare(path) != 0) {
-		closeEditor();
 		unloadEffect();
 		blog(LOG_INFO, "User selected new VST plugin: '%s'", path.c_str());
 	}
@@ -264,6 +263,8 @@ obs_audio_data *VSTPlugin::process(struct obs_audio_data *audio)
 
 void VSTPlugin::unloadEffect()
 {
+	closeEditor();
+
 	{
 		std::lock_guard<std::recursive_mutex> lock(lockEffect);
 
@@ -279,6 +280,8 @@ void VSTPlugin::unloadEffect()
 	}
 
 	unloadLibrary();
+
+	pluginPath = "";
 }
 
 bool VSTPlugin::isEditorOpen()

--- a/obs-vst.cpp
+++ b/obs-vst.cpp
@@ -99,6 +99,7 @@ static void vst_update(void *data, obs_data_t *settings)
 	const char *path = obs_data_get_string(settings, "plugin_path");
 
 	if (strcmp(path, "") == 0) {
+		vstPlugin->unloadEffect();
 		return;
 	}
 	vstPlugin->loadEffectFromPath(std::string(path));


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
clear effect if no VST is selected

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
fix bug

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
select any valid VST plugin;
select item in plugin list : "please select VST plugin"
check old effect state, there should no effect to apply

### Types of changes
Bug fix (non-breaking change which fixes an issue)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- -  -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
