### PR TITLE
Update find_qt macro usage in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ mark_as_advanced(ENABLE_VST_BUNDLED_HEADERS)
 add_library(obs-vst MODULE)
 add_library(OBS::vst ALIAS obs-vst)
 
-find_qt(VERSION ${QT_VERSION} COMPONENTS Widgets)
+find_qt(COMPONENTS Widgets)
 
 set_target_properties(
   obs-vst

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,41 +1,5 @@
 project(obs-vst)
 
-macro(find_qt)
-  set(oneValueArgs VERSION)
-  set(multiValueArgs COMPONENTS COMPONENTS_WIN COMPONENTS_MAC COMPONENTS_LINUX)
-  cmake_parse_arguments(FIND_QT "" "${oneValueArgs}" "${multiValueArgs}"
-                        ${ARGN})
-
-  if(OS_WINDOWS)
-    find_package(
-      Qt${FIND_QT_VERSION}
-      COMPONENTS ${FIND_QT_COMPONENTS} ${FIND_QT_COMPONENTS_WIN}
-      REQUIRED)
-  elseif(OS_MACOS)
-    find_package(
-      Qt${FIND_QT_VERSION}
-      COMPONENTS ${FIND_QT_COMPONENTS} ${FIND_QT_COMPONENTS_MAC}
-      REQUIRED)
-  else()
-    find_package(
-      Qt${FIND_QT_VERSION}
-      COMPONENTS ${FIND_QT_COMPONENTS} ${FIND_QT_COMPONENTS_LINUX}
-      REQUIRED)
-  endif()
-
-  foreach(_COMPONENT IN LISTS FIND_QT_COMPONENTS FIND_QT_COMPONENTS_WIN
-                              FIND_QT_COMPONENTS_MAC FIND_QT_COMPONENTS_LINUX)
-    if(NOT TARGET Qt::${_COMPONENT} AND TARGET
-                                        Qt${FIND_QT_VERSION}::${_COMPONENT})
-
-      add_library(Qt::${_COMPONENT} INTERFACE IMPORTED)
-      set_target_properties(
-        Qt::${_COMPONENT} PROPERTIES INTERFACE_LINK_LIBRARIES
-                                     "Qt${FIND_QT_VERSION}::${_COMPONENT}")
-    endif()
-  endforeach()
-endmacro()
-
 option(ENABLE_VST "Enable building OBS with VST plugin" ON)
 
 if(NOT ENABLE_VST)
@@ -45,14 +9,6 @@ endif()
 
 option(ENABLE_VST_BUNDLED_HEADERS "Build with Bundled Headers" ON)
 mark_as_advanced(ENABLE_VST_BUNDLED_HEADERS)
-
-if(NOT QT_VERSION)
-  set(QT_VERSION
-      "5"
-      CACHE STRING
-            "OBS Qt version [5, 6]" FORCE)
-  set_property(CACHE QT_VERSION PROPERTY STRINGS 5 6)
-endif()
 
 add_library(obs-vst MODULE)
 add_library(OBS::vst ALIAS obs-vst)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

To make obs-vst work with https://github.com/obsproject/obs-studio/pull/6782.

QT_VERSION and find_qt definiation are not needed since the plugin is only buildable in-tree.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Allow to automatically use whether Qt5 or Qt6 is available and if both are present prefer Qt5.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Check https://github.com/obsproject/obs-studio/pull/6782.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
