### PR TITLE
Fix type mismatch when building with Qt6

### DIFF
--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -387,7 +387,7 @@ void VSTPlugin::setChunk(std::string data)
 		const char * p_chars  = paramData.data();
 		const float *p_floats = reinterpret_cast<const float *>(p_chars);
 
-		int size = paramData.length() / sizeof(float);
+		const size_t size = paramData.length() / sizeof(float);
 
 		std::vector<float> params(p_floats, p_floats + size);
 


### PR DESCRIPTION
### Description
QByteArray size is now qsizetype instead of int.

### Motivation and Context
Fixes compiler warning (as error).

### How Has This Been Tested?
Code compiles now.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.